### PR TITLE
python3.5 uses mo.group('name') instead of mo['name']

### DIFF
--- a/neuropythy/commands/atlas.py
+++ b/neuropythy/commands/atlas.py
@@ -105,7 +105,7 @@ def calc_atlases(worklog, atlas_subject_id='fsaverage'):
             if m is None: continue
             fl = os.path.join(pth, fl)
             (h, atls, meas, vrsn) = [
-                m[ii] for ii in (atlas_hemi_ii, atlas_atls_ii, atlas_meas_ii, atlas_vrsn_ii)]
+                m.group(ii) for ii in (atlas_hemi_ii, atlas_atls_ii, atlas_meas_ii, atlas_vrsn_ii)]
             if vrsn is not None: vrsn = tuple([int(s) for s in vrsn.split('_')])
             atlases[atls][vrsn][h][meas] = curry(nyio.load, fl)
     # convert the possible atlas maps into persistent/lazy maps


### PR DESCRIPTION
``m[ii]`` raises error in python 2.7 and python 3.5 because this syntax was added in [python 3.6](https://docs.python.org/3/whatsnew/3.6.html#re).

