### PR TITLE
changes mri/core.py weight -> weights

### DIFF
--- a/neuropythy/mri/core.py
+++ b/neuropythy/mri/core.py
@@ -569,7 +569,7 @@ class Subject(ObjectWithMetaData):
         return arr
     def image_to_cortex(self, image,
                         surface='midgray', hemi=None, affine=None, method=None, fill=0, dtype=None,
-                        weight=None):
+                        weights=None):
         '''
         sub.image_to_cortex(image) is equivalent to the tuple
           (sub.lh.from_image(image), sub.rh.from_image(image)).
@@ -579,12 +579,12 @@ class Subject(ObjectWithMetaData):
         hemi = hemi.lower()
         if hemi in ['both', 'lr', 'all', 'auto']:
             return tuple([self.image_to_cortex(image, surface=surface, hemi=h, affine=affine,
-                                               method=method, fill=fill, dtype=dtype, weight=weight)
+                                               method=method, fill=fill, dtype=dtype, weights=weights)
                           for h in ['lh', 'rh']])
         else:
             hemi = getattr(self, hemi)
             return hemi.from_image(image, surface=surface, affine=affine,
-                                   method=method, fill=fill, dtype=dtype, weight=weight,
+                                   method=method, fill=fill, dtype=dtype, weights=weights,
                                    native_to_vertex_matrix=self.native_to_vertex_matrix)
 def is_subject(s):
     '''
@@ -728,14 +728,14 @@ class Cortex(geo.Topology):
         else:
             raise ValueError('could not understand surface layer: %s' % name)
     def from_image(self, image, surface='midgray', affine=None, method=None, fill=0, dtype=None,
-                   native_to_vertex_matrix=None, weight=None):
+                   native_to_vertex_matrix=None, weights=None):
         '''
         cortex.from_image(image) is equivalent to cortex.midgray_surface.from_image(image).
         cortex.from_image(image, surface) uses the given surface (see also cortex.surface).
         '''
         mesh = self.surface(surface) if not isinstance(surface, geo.Mesh) else surface
         return mesh.from_image(image, affine=affine, method=method, fill=fill, dtype=dtype,
-                               native_to_vertex_matrix=native_to_vertex_matrix, weight=weight)
+                               native_to_vertex_matrix=native_to_vertex_matrix, weights=weights)
     def address(self, data, indices=None, native_to_vertex_matrix=None):
         '''
         cortex.address(points) yields the barycentric coordinates of the given point or points; the


### PR DESCRIPTION
Addresses #7 

This corrects a bug where mesh.from_image wouldn't run because the
kwarg was weight, instead of weights. this changes all the arguments
to weights in order to make it consistent with geometric/mesh.py,
where the argument / keyword weights seems way more common than here.

I ran the tests (`python -m unittest neuropythy.test`) and everything worked, not sure if there's any other tests to run.