### PR TITLE
AttributeError: 'ArrayProxy' correction

### DIFF
--- a/neuropythy/commands/surface_to_image.py
+++ b/neuropythy/commands/surface_to_image.py
@@ -84,7 +84,7 @@ _surface_to_ribbon_parser = pimms.argv_parser(_surface_to_ribbon_parser_instruct
 
 def read_surf_file(flnm):
   if flnm.endswith(".mgh") or flnm.endswith(".mgz"):
-    data = fsmgh.load(flnm).dataobj.flatten()
+    data = np.array(fsmgh.load(flnm).dataobj).flatten()
   else:
     data = fsio.read_morph_data(flnm)
   return data


### PR DESCRIPTION
AttributeError: 'ArrayProxy' object has no attribute 'flatten'

python -m neuropythy surface_to_image "${SUBJECT_ID}"        --lh=$SUBJECTS_DIR/"${SUBJECT_ID}"/surf/lh.benson14_varea.mgz        --rh=$SUBJECTS_DIR/"${SUBJECT_ID}"/surf/rh.benson14_varea.mgz        $SUBJECTS_DIR/"${SUBJECT_ID}"/mri/varea.mgz
/opt/freesurfer/subjects/TOME_3024/surf/lh.benson14_varea.mgz
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/local/lib/python2.7/dist-packages/neuropythy/__main__.py", line 19, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/usr/local/lib/python2.7/dist-packages/neuropythy/__main__.py", line 16, in main
    return commands[argv[0]](argv[1:])
  File "/usr/local/lib/python2.7/dist-packages/neuropythy/commands/surface_to_image.py", line 193, in main
    lhdat = read_surf_file(lhfl)
  File "/usr/local/lib/python2.7/dist-packages/neuropythy/commands/surface_to_image.py", line 88, in read_surf_file
    data = fsmgh.load(flnm).dataobj.flatten()
AttributeError: 'ArrayProxy' object has no attribute 'flatten'