### PR TITLE
Minor changes for plotting 2D mesh and revision for notations in hcp subject 

### DIFF
--- a/neuropythy/graphics/core.py
+++ b/neuropythy/graphics/core.py
@@ -986,7 +986,7 @@ def cortex_plot_colors(the_map,
       * vmax (default: None) specifies the maximum value for scaling the property when one is passed
         as the color option. None means to use the max value of the property.
       * underlay (default: 'curvature') specifies the default underlay color to plot for the
-        cortical surface; it may be None, 'curvature', or a color.
+        cortical surface; it may be None, 'curvature', a color, or an ndarray compatible to the map.
       * alpha (default None) specifies the alpha values to use for the color plot. If None, then
         leaves the alpha values from color unchanged. If a single number, then all alpha values in
         color are multiplied by that value. If a list of values, one per vertex, then this vector
@@ -1047,6 +1047,10 @@ def cortex_plot_colors(the_map,
     if underlay is not None:
         if pimms.is_str(underlay) and underlay.lower() in ['curvature', 'curv']:
             underlay = apply_cmap(the_map.prop('curvature'), cmap_curvature, vmin=-1, vmax=1)
+        elif  isinstance(underlay, np.ndarray):
+            if the_map.vertex_count == underlay.size:
+                 underlay = apply_cmap(underlay, cmap_curvature, vmin=-1, vmax=1)
+            else: raise ValueError('ndarray underlay should have the same vertices with flatmap')
         else:
             try: underlay = np.ones((the_map.vertex_count, 4)) * to_rgba(underlay)
             except Exception: raise ValueError('plot underlay failed: must be a color or curvature')
@@ -1091,7 +1095,7 @@ def cortex_plot_2D(the_map,
       * vmax (default: None) specifies the maximum value for scaling the property when one is passed
         as the color option. None means to use the max value of the property.
       * underlay (default: 'curvature') specifies the default underlay color to plot for the
-        cortical surface; it may be None, 'curvature', or a color.
+        cortical surface; it may be None, 'curvature', a color, or an ndarray compatible to the map.
       * alpha (default None) specifies the alpha values to use for the color plot. If None, then
         leaves the alpha values from color unchanged. If a single number, then all alpha values in
         color are multiplied by that value. If a list of values, one per vertex, then this vector
@@ -1311,7 +1315,7 @@ def cortex_plot(mesh, *args, **opts):
       * vmax (default: None) specifies the maximum value for scaling the property when one is passed
         as the color option. None means to use the max value of the property.
       * underlay (default: 'curvature') specifies the default underlay color to plot for the
-        cortical surface; it may be None, 'curvature', or a color.
+        cortical surface; it may be None, 'curvature', a color, or an ndarray compatible to the map.
       * alpha (default None) specifies the alpha values to use for the color plot. If None, then
         leaves the alpha values from color unchanged. If a single number, then all alpha values in
         color are multiplied by that value. If a list of values, one per vertex, then this vector

--- a/neuropythy/hcp/core.py
+++ b/neuropythy/hcp/core.py
@@ -199,7 +199,7 @@ def subject(path, name=Ellipsis, meta_data=None, check_path=True, filter=None,
       * meta_data (default: None) may optionally be a map that contains meta-data to be passed along
         to the subject object (note that this meta-data will not be cached).
       * check_path (default: True) may optionally be set to False to ignore the requirement that a
-        directory contain at least the mri/, label/, and surf/ directories to be considered a valid
+        directory contain at least the T1w/, MNINonLinear/ directories to be considered a valid
         HCP subject directory. Subject objects returned when this argument is not True are not
         cached. Additionally, check_path may be set to None instead of False, indicating that no
         sanity checks or search should be performed whatsoever: the string name should be trusted 


### PR DESCRIPTION
Hi Benson, 
     I make the changes in plot codes for my own circumstance, and you may decide whether it's common: 
    1. I have had pRF analysis in **MNInonlinear fsLR32k space** for each participants, thus thery all have 59k vertices on the cortex.
    2. I find the index vector **ciftifsaverageix** which transfer indices from fsLR space to fsaverage space in openscience platform, then all subject will have around 320k vertices after re-indexing.
    3. I find the mentioned index vector cannot work on individual surface (after re-indexing, the plotting of parameters on sphere seems like an oily cryon drawing being rubbed by an eraser and without any meaningful pattern)   
    4. Thus, advised by my supervisor, I try to transfer curvature in fsLR space into fsaverage space and plot the transfered curvature as underlay, but the default code cannot support an ndarray object as input, then I change the code and find it works.