### PR TITLE
[FIX] change extra to empty dict if it remains ellipsis

### DIFF
--- a/neuropythy/freesurfer/core.py
+++ b/neuropythy/freesurfer/core.py
@@ -989,7 +989,7 @@ def to_mgh(obj, like=None, header=None, affine=None, extra=Ellipsis):
             affine = obj.affine
         else:
             affine = np.eye(4)
-    if extra is None: extra = {}
+    if extra is None or extra is Ellipsis: extra = {}
     # Figure out what the data is
     if isinstance(obj, nib.analyze.SpatialImage):
         obj = obj.dataobj


### PR DESCRIPTION
Dear Noah, dear neuropythists,

I tried to run the atlas command from neuropythy as described in your README.md:

`
python -m neuropythy atlas --verbose $SUBJECT_ID
`

Unfortunately this command crashed with the following message when attempting to write the output files to disk:


```
* Extracting Files...
     * /HOME/experiments/GrandBudapestHotel/data/derivatives/fMRIprep/
        sourcedata/freesurfer/sub-sid000005/surf/rh.benson14_sigma.mgz
Traceback (most recent call last):
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/neuropythy/__main__.py", line 19, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/neuropythy/__main__.py", line 16, in main
    return commands[argv[0]](argv[1:])
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/neuropythy/commands/atlas.py", line 487, in main
    try: imap['export_all_fn']()
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/neuropythy/commands/atlas.py", line 407, in export_all
    filenames.append(nyio.save(flnm, filemap[flnm], fmt))
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/neuropythy/io/core.py", line 213, in save
    return f(filename, data, **kwargs)
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/neuropythy/freesurfer/core.py", line 1017, in save_mgh
    obj = to_mgh(obj, like=like, header=header, affine=affine, extra=extra)
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/neuropythy/freesurfer/core.py", line 1005, in to_mgh
    obj = fsmgh.MGHImage(obj, affine, header=header, extra=extra)
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/nibabel/freesurfer/mghformat.py", line 481, in __init__
    super().__init__(dataobj, affine, header=header, extra=extra, file_map=file_map)
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/nibabel/spatialimages.py", line 514, in __init__
    super().__init__(dataobj, header=header, extra=extra, file_map=file_map)
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/nibabel/dataobj_images.py", line 62, in __init__
    super().__init__(header=header, extra=extra, file_map=file_map)
  File "/opt/miniconda-latest/envs/neuro/lib/python3.8/site-packages/nibabel/filebasedimages.py", line 194, in __init__
    self.extra = dict(extra)
TypeError: 'ellipsis' object is not iterable
```

The error is occurs in nibabel, which is the latest version, i.e. 5.1.0, in my case.

The problem with the neuropythy code is that it passes a variable of type "ellipsis" as input argument "extra" to a nibabel's MGHImage object that expects either a mapping or None. I prevented that from happening by checking if it is still Ellipsis just before creating an object of that class and replacing it with an empty dict, which seems to be acceptable as well.

The code now runs as expected.

I hope you'll find this useful.

Cheers,
Michael